### PR TITLE
support --build-type argument for debug/release build

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ of something, as we need to prioritize quite often.
 
 ## Changelog
 
+- _1.3.0_ The Debug/Release will propagate to the conan profile. (thanks to @xandox)
 - _1.2.0_ Workaround for Windows and MSVC found by Ramin Kosfeld (TU Braunschweig).
 - _1.1.1_ Fixing problem if the conan default profile has been renamed via environment variable.
 - _1.1.0_ conan is now called directly. This is kind of hacky, but circumvents problems with conan not being in the path if only installed for build.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ where = ["src"]
 
 [project]
 name = "skbuild_conan"
-version = "v1.2.0"
+version = "v1.3.0"
 authors = [
     { name = "TU Braunschweig, IBR, Algorithms Group (Dominik Krupke)", email = "krupke@ibr.cs.tu-bs.de" },
 ]

--- a/src/skbuild_conan/conan_helper.py
+++ b/src/skbuild_conan/conan_helper.py
@@ -8,6 +8,7 @@ from contextlib import redirect_stdout
 
 from conan.cli.cli import Cli as ConanCli
 from conan.api.conan_api import ConanAPI
+import conan
 
 
 class EnvContextManager:
@@ -94,9 +95,8 @@ class ConanHelper:
         return out
 
     def conan_version(self):
-        args = ["-v"]
-        version = self._conan_cli(args).split(" ")[-1]
-        return version
+        return conan.__version__
+
 
     def _check_conan_version(self):
         self._log("Checking Conan version...")

--- a/src/skbuild_conan/setup_wrapper.py
+++ b/src/skbuild_conan/setup_wrapper.py
@@ -90,28 +90,18 @@ def setup(
 
     except Exception as e:
         # Setup could not be completed. Give debugging information in red and abort.
-        print(f"\033[91m[skbuild-conan] {e}\033[0m")
-        print(
-            "\033[91m[skbuild-conan] skbuild_conan failed to install dependencies.\033[0m"
-        )
-        print("There are several reasons why this could happen:")
-        print(
-            "1. A mistake by the developer of the package you are trying to install."
-            + " Maybe a wrongly defined dependency?"
-        )
-        print("2. An unexpected conflict with an already existing conan configuration.")
-        print("3. A rare downtime of the conan package index.")
-        print(
-            "4. A bug in skbuild_conan. Please report it at https://github.com/d-krupke/skbuild-conan/issues"
-        )
-        print(
-            "5. Your system does not have a C++-compiler installed. Please install one."
-        )
-        print(
-            "6. You conan profile is not configured correctly. "
-            + f"Please check `~/.conan2/profiles/{conan_profile}`. "
-            + "You can also try to just delete `./conan2/` to reset conan completely."
-        )
+        error_message = f"""
+    \033[91m[skbuild-conan] {e}\033[0m
+    \033[91m[skbuild-conan] skbuild_conan failed to install dependencies.\033[0m
+    There are several reasons why this could happen:
+    1. A mistake by the developer of the package you are trying to install. Maybe a wrongly defined dependency?
+    2. An unexpected conflict with an already existing conan configuration.
+    3. A rare downtime of the conan package index.
+    4. A bug in skbuild_conan. Please report it at https://github.com/d-krupke/skbuild-conan/issues
+    5. Your system does not have a C++-compiler installed. Please install one.
+    6. Your conan profile is not configured correctly. Please check `~/.conan2/profiles/{conan_profile}`. You can also try to just delete `./conan2/` to reset conan completely.
+    """
+        print(error_message)
         raise e
     print(
         "[skbuild-conan] Setup of conan dependencies finished. cmake args:", cmake_args
@@ -123,8 +113,13 @@ def setup(
 
 
 def parse_args() -> str:
-    """This function parses the command-line arguments ``sys.argv`` and returns
-    build_type as a string. Release or Debug."""
+    """
+    This function parses the command-line arguments ``sys.argv`` and returns
+    build_type as a string. Release or Debug.
+
+    This is consistent with the interface of the underlying scikit-build, which
+    will also read this argument and change its behavior accordingly.
+    """
 
     import argparse
 


### PR DESCRIPTION
It works, but not entirely as expected.
Maintaining both debug and release builds simultaneously does not work. I believe this is because `scikit-build` uses the same build directory for both debug and release builds.