### PR TITLE
latest version for pybind11

### DIFF
--- a/examples/cgal_skbuild_conan_example/src/cgal_skbuild_conan_example/CMakeLists.txt
+++ b/examples/cgal_skbuild_conan_example/src/cgal_skbuild_conan_example/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Created by the script cgal_create_cmake_script This is the CMake script for
 # compiling a CGAL application.
-cpmaddpackage("gh:pybind/pybind11@2.10.0") # pybind11, essential
+cpmaddpackage("gh:pybind/pybind11@2.13.6") # pybind11, essential
 find_package(CGAL REQUIRED)
 find_package(fmt REQUIRED)
 

--- a/examples/cgal_skbuild_conanio_example/src/cgal_skbuild_conanio_example/CMakeLists.txt
+++ b/examples/cgal_skbuild_conanio_example/src/cgal_skbuild_conanio_example/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Created by the script cgal_create_cmake_script This is the CMake script for
 # compiling a CGAL application.
-cpmaddpackage("gh:pybind/pybind11@2.10.0") # pybind11, essential
+cpmaddpackage("gh:pybind/pybind11@2.13.6") # pybind11, essential
 find_package(CGAL REQUIRED)
 find_package(fmt REQUIRED)
 


### PR DESCRIPTION
leads to a compiler error because in the old pybind11 versions, a 'cmake_minimum_required' version is used which is too old.